### PR TITLE
Update dependencies

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,3 +1,3 @@
 #lang info
 
-(define deps '("x11" "base" "rackunit-lib" "slideshow-lib" "readline-lib"))
+(define deps '("x11" "base" "rackunit-lib" "slideshow-lib" "readline-lib" "gui-lib"))


### PR DESCRIPTION
On pkgs.racket-lang.org, it says that gui-lib is missing from the required dependencies.