### PR TITLE
The REPL server errors when writing values

### DIFF
--- a/server.rkt
+++ b/server.rkt
@@ -66,10 +66,15 @@
                      (λ()
                        ;(printf "BEFORE EVAL")(flush-output)
                        (with-output-to-string
-                        (λ()
-                          (define r (eval e server-namespace))
+                        (λ ()
+                          #|(define r (eval e server-namespace))
                           (unless (void? r)
-                            (write r)))))
+                            (write r))|#
+                          (for-each (λ (retval)
+                                      (unless (void? retval)
+                                        (write retval)
+                                        (newline)))
+                                    (call-with-values (λ () (eval e server-namespace)) list)))))
                      (λ()
                        ;(printf "BETWEEN EVAL AND FLUSH")(flush-output)
                        (XFlush (current-display))


### PR DESCRIPTION
This fix will tell the REPL server to print each value and append a newline.